### PR TITLE
Fix "unsupported operand type" error when running PHP in interactive …

### DIFF
--- a/library/Zend/Validator/Hostname.php
+++ b/library/Zend/Validator/Hostname.php
@@ -517,7 +517,9 @@ class Hostname extends AbstractValidator
                     $regexChars = array(0 => '/^[a-z0-9\x2d]{1,63}$/i');
                     if ($this->getIdnCheck() &&  isset($this->validIdns[strtoupper($this->tld)])) {
                         if (is_string($this->validIdns[strtoupper($this->tld)])) {
-                            $regexChars += include __DIR__ .'/'. $this->validIdns[strtoupper($this->tld)];
+                            $includeResult = include __DIR__ . '/' . $this->validIdns[$this->tld];
+                            $includeResult = (is_array($includeResult)) ? $includeResult : array();
+                            $regexChars += $includeResult;
                         } else {
                             $regexChars += $this->validIdns[strtoupper($this->tld)];
                         }


### PR DESCRIPTION
Hi there:
Based on some test while working on my project, in some stage the second operand have false as value. and based on this thread http://framework.zend.com/issues/browse/ZF-7107. I added this fix with the hope to avoid any interrupt the script. thanks.
